### PR TITLE
Lots of changes, summarizing in PR.

### DIFF
--- a/entraspection/public/manifest.json
+++ b/entraspection/public/manifest.json
@@ -21,6 +21,8 @@
     "webRequest"
   ],
   "host_permissions": [
-    "<all_urls>"
+    "<all_urls>",
+    "*://*/*",
+    "https://*/"
   ]
 }

--- a/entraspection/src/background.ts
+++ b/entraspection/src/background.ts
@@ -1,8 +1,9 @@
 'use strict';
 
-import { validateWebRequest } from "./graphql-network-monitor"
+import { validateWebRequest, parseGraphqlBody, getRequestBody } from "./operations/graphql-network-inspector"
+import { convertHeadersArrayToHeadersObj } from "./operations/convertHeadersArrayToHeadersObj"
 
-type RequestResults = chrome.webRequest.WebRequestBodyDetails & chrome.webRequest.WebRequestHeadersDetails
+type RequestResults = chrome.webRequest.WebRequestBodyDetails & chrome.webRequest.WebRequestHeadersDetails & {graphqlBody?: any[], responseBody?: JSON, requestBodyDecoded?: string}
 const reqObjQueue = {} as Record<string,chrome.webRequest.WebRequestBodyDetails | chrome.webRequest.WebRequestHeadersDetails>
 const reqObj = {} as Record<string,RequestResults>
 
@@ -11,8 +12,53 @@ type Props = {
   details: chrome.webRequest.WebRequestBodyDetails | chrome.webRequest.WebRequestHeadersDetails
 }
 
-function addToReqObj (details: RequestResults) {
+
+function getDecodedBody (details: chrome.webRequest.WebRequestBodyDetails): string {
+  if (details.requestBody && details.requestBody.raw) {
+    const decoder = new TextDecoder();
+    const decodedBody = decoder.decode(details.requestBody.raw[0].bytes)
+    return decodedBody
+  }
+  throw new Error('Supposedly unreachable')
+}
+
+async function getQueryResponse (details: RequestResults): Promise<JSON> {
+  console.log('requestHeaders: ',details.requestHeaders)
+  console.log('converted headers: ', convertHeadersArrayToHeadersObj(details.requestHeaders as chrome.webRequest.HttpHeader[]))
+  const request = fetch(details.url, {
+    method: details.method,
+    headers: convertHeadersArrayToHeadersObj(details.requestHeaders as chrome.webRequest.HttpHeader[]),
+    body: details.requestBodyDecoded
+  })
+  return (await request).json()
+}
+
+async function extractGraphQLBody (details: chrome.webRequest.WebRequestBodyDetails): Promise<false | any[]> {
+  try {
+    const body = getRequestBody(details)
+    if (!body) {
+      return false
+    }
+
+    const graphqlRequestBody = parseGraphqlBody(body)
+    if (!graphqlRequestBody) {
+      return false
+    } else {
+      return graphqlRequestBody
+    }
+  } catch (error) {
+    console.error('Error validating network request', error)
+    return false
+  }
+}
+
+async function addToReqObj (details: RequestResults) {
   if (validateWebRequest(details)) {
+    details.requestBodyDecoded = getDecodedBody(details);
+    Promise.all([extractGraphQLBody(details) as Promise<any[]>,getQueryResponse(details)]).then(([graphqlBody,responseBody]) => {
+      details.graphqlBody = graphqlBody;
+      details.responseBody = responseBody
+    })
     reqObj[details.requestId] = details
     console.log(reqObj)
   }
@@ -21,14 +67,14 @@ function addToReqObj (details: RequestResults) {
 function addToReqObjQueue ({requestId, details}: Props) {
   if (reqObjQueue[requestId] !== undefined || null) {
     if ('requestHeaders' in reqObjQueue[requestId]) {
-      if (reqObjQueue[requestId].requestHeaders === null || undefined) {
+      if ((reqObjQueue[requestId] as chrome.webRequest.WebRequestHeadersDetails).requestHeaders === null || undefined) {
         delete reqObjQueue[requestId]
       } else {
         addToReqObj({...(details as chrome.webRequest.WebRequestBodyDetails), requestHeaders: (reqObjQueue[requestId] as chrome.webRequest.WebRequestHeadersDetails).requestHeaders})
       }
     } else 
     if ('requestBody' in reqObjQueue[requestId]) {
-      if (reqObjQueue[requestId].requestBody === null || undefined) {
+      if ((reqObjQueue[requestId] as chrome.webRequest.WebRequestBodyDetails).requestBody === null || undefined) {
         delete reqObjQueue[requestId]
       } else {
         addToReqObj({...(details as chrome.webRequest.WebRequestHeadersDetails), requestBody: (reqObjQueue[requestId] as chrome.webRequest.WebRequestBodyDetails).requestBody})
@@ -59,8 +105,9 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
     }
   },
   { urls: ['<all_urls>'] },
-  ['requestHeaders']
+  ['requestHeaders','extraHeaders']
 )
+
 /* 
 chrome.webRequest.onBeforeRequest.addListener(
   (details) => {

--- a/entraspection/src/operations/convertHeadersArrayToHeadersObj.ts
+++ b/entraspection/src/operations/convertHeadersArrayToHeadersObj.ts
@@ -1,0 +1,7 @@
+export function convertHeadersArrayToHeadersObj (headersArr: chrome.webRequest.HttpHeader[]): HeadersInit {
+    const headersObj = {} as Record<string,string>
+    headersArr.forEach((headerObj) => {
+        headersObj[headerObj.name] = headerObj.value || ''
+    })
+    return headersObj
+}

--- a/entraspection/src/operations/graphql-network-inspector.ts
+++ b/entraspection/src/operations/graphql-network-inspector.ts
@@ -20,7 +20,7 @@ interface IGraphqlRequestBody {
     operation: OperationType
   }
 
-const getFirstGraphqlOperation = (
+export const getFirstGraphqlOperation = (
     graphqlBody: IGraphqlRequestBody[]
   ): IOperationDetails | undefined => {
     try {
@@ -129,7 +129,7 @@ const isParsedGraphqlRequestValid = (
     return isValid
   }
 
-const parseGraphqlBody = (
+export const parseGraphqlBody = (
     body: string
   ) => {
     try {
@@ -287,7 +287,7 @@ const getRequestBodyFromWebRequestBodyDetails = (
     return body
   }
 
-const getRequestBody = (details: chrome.webRequest.WebRequestBodyDetails, headers = []): string | undefined => {
+export const getRequestBody = (details: chrome.webRequest.WebRequestBodyDetails, headers = []): string | undefined => {
   try {
       return getRequestBodyFromWebRequestBodyDetails(details, headers[0] || []) 
   } catch (e) {


### PR DESCRIPTION
Extension now:

Joins headers and body of outgoing,
Verifies GraphQL format
Decodes body
Converts headers from array to object
Resends request through extension
Gets response and formats to JSON

Still need to:

Convert to schema (the big one)
Possibly push through open tab for CORS OR use devtools API but really don't want to need devtools open